### PR TITLE
Fix jira/CSD-8256

### DIFF
--- a/Capture-Raw-Video-Data/Agora-Plugin-Raw-Data-API-Android-Java/raw-data-api-java/src/main/java/io/agora/rtc/plugin/rawdata/MediaDataObserverPlugin.java
+++ b/Capture-Raw-Video-Data/Agora-Plugin-Raw-Data-API-Android-Java/raw-data-api-java/src/main/java/io/agora/rtc/plugin/rawdata/MediaDataObserverPlugin.java
@@ -25,7 +25,7 @@ public class MediaDataObserverPlugin implements MediaPreProcessing.ProgressCallb
     private final List<MediaDataVideoObserver> videoObserverList = new ArrayList<>();
     private final List<MediaDataAudioObserver> audioObserverList = new ArrayList<>();
 
-    private static final int VIDEO_DEFAULT_BUFFER_SIZE = 1920 * 720; // default maximum video size 720P
+    private static final int VIDEO_DEFAULT_BUFFER_SIZE = 3240 * 1080; // default maximum video size Full HD+
     private static final int AUDIO_DEFAULT_BUFFER_SIZE = 2048;
 
     public ByteBuffer byteBufferCapture = ByteBuffer.allocateDirect(VIDEO_DEFAULT_BUFFER_SIZE);


### PR DESCRIPTION
The default video buffer size is smaller than the actual video size
which results the crash.

Enlarge the default video buffer size to Full HD+ size.