### PR TITLE
added Agora dependancy to Gradle

### DIFF
--- a/Screensharing/Agora-Screen-Sharing-Android/app/build.gradle
+++ b/Screensharing/Agora-Screen-Sharing-Android/app/build.gradle
@@ -24,6 +24,7 @@ dependencies {
     implementation fileTree(include: ['*.jar'], dir: 'libs')
     implementation 'com.android.support.constraint:constraint-layout:1.1.3'
     implementation 'com.android.support:appcompat-v7:26.1.0'
+    implementation 'io.agora.rtc:full-sdk:2.3.+'
     testImplementation 'junit:junit:4.12'
     androidTestImplementation('com.android.support.test.espresso:espresso-core:2.2.2', {
         exclude group: 'com.android.support', module: 'support-annotations'


### PR DESCRIPTION
Added missing dependency, README states dependency is there but it wasn't.


>(This sample program has added this address and do not need to add again. Adding the link address is the most important step if you want to integrate the Agora Video SDK in your own application.)