### PR TITLE
Fix CSD-10347. Fix wrong size state for the end of video stream.

### DIFF
--- a/Custom-Media-Device/Agora-Custom-Media-Device-Android/app/src/main/java/io/agora/rtc/mediaio/app/videoSource/source/AgoraLocalVideoSource.java
+++ b/Custom-Media-Device/Agora-Custom-Media-Device-Android/app/src/main/java/io/agora/rtc/mediaio/app/videoSource/source/AgoraLocalVideoSource.java
@@ -237,7 +237,7 @@ public class AgoraLocalVideoSource extends TextureSource {
                             signaledEos = (size == -1);
                             mDecoder.queueInputBuffer(inputBufferIndex,
                                     0,
-                                    size,
+                                    signaledEos ? 0 : size,
                                     timestampUs,
                                     signaledEos ? MediaCodec.BUFFER_FLAG_END_OF_STREAM : 0);
                         }


### PR DESCRIPTION
The last input of the end of the video stream should be assigned a size 0 instead of -1 (which causes an illegal argument exception)